### PR TITLE
Update thrust calculation to include StartUT

### DIFF
--- a/src/BackgroundThrust/ThrustParameters.cs
+++ b/src/BackgroundThrust/ThrustParameters.cs
@@ -73,7 +73,7 @@ public struct ThrustParameters
         var deltaM = DeltaM;
         if (Math.Abs(deltaM) < 1e-6)
         {
-            return dv * StartMass / thrust;
+             return StartUT + dv * StartMass / thrust;
         }
         else
         {

--- a/src/BackgroundThrust/ThrustParameters.cs
+++ b/src/BackgroundThrust/ThrustParameters.cs
@@ -73,7 +73,7 @@ public struct ThrustParameters
         var deltaM = DeltaM;
         if (Math.Abs(deltaM) < 1e-6)
         {
-             return StartUT + dv * StartMass / thrust;
+            return StartUT + dv * StartMass / thrust;
         }
         else
         {


### PR DESCRIPTION
Fixes an inconsistency in `ThrustParameters.GetUTAtDeltaV()` when vessel mass change is effectively zero.

`GetUTAtDeltaV()` is used as an absolute UT estimate. The normal mass-flow branch returns `StartUT + duration`, but the near-zero-mass-flow branch returned only `duration`:

```csharp
return dv * StartMass / thrust;
```

That causes callers such as maneuver-node thrust integration to compute:

```csharp
remainingT = Math.Max(estimateUT - parameters.StartUT, 0.0);
```

as zero once `StartUT` is larger than the burn duration. For very low mass-flow or effectively massless thrust cases, this can make maneuver-mode BackgroundThrust believe the burn has no remaining time and immediately reduce timewarp.

This patch changes the near-zero-mass-flow branch to return the same absolute time base as the normal branch:

```csharp
return StartUT + dv * StartMass / thrust;
```